### PR TITLE
Fixed issues with generic i2c arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 - Moved to [embedded-hal](https://github.com/rust-embedded/embedded-hal) v1.0.
+- Fixed issues with generic i2c arguments
 
 ## [0.1.1] - 2022-09-15
 

--- a/src/common/common_impl.rs
+++ b/src/common/common_impl.rs
@@ -1,14 +1,14 @@
 use crate::{register_access::Register, Error, Mma8x5x};
 use embedded_hal::i2c::{I2c, SevenBitAddress};
 
-impl<I2C, IC, MODE> Mma8x5x<I2C, IC, MODE> {
+impl<I2C: I2c, IC, MODE> Mma8x5x<I2C, IC, MODE> {
     /// Destroy driver instance, return I²C bus and delay instance.
     pub fn destroy(self) -> I2C {
         self.i2c
     }
 }
 
-impl<E, I2C, IC, MODE> Mma8x5x<I2C, IC, MODE>
+impl<E, I2C: I2c, IC, MODE> Mma8x5x<I2C, IC, MODE>
 where
     I2C: I2c<SevenBitAddress, Error = E>,
 {

--- a/src/mma845x.rs
+++ b/src/mma845x.rs
@@ -1,7 +1,9 @@
+use embedded_hal::i2c::I2c;
+
 use crate::{ic, mode, register_access::BitFlags, Config, Mma8x5x, SlaveAddr, MMA845X_BASE_ADDR};
 use core::marker::PhantomData;
 
-impl<I2C> Mma8x5x<I2C, ic::Mma8451, mode::Standby> {
+impl<I2C: I2c> Mma8x5x<I2C, ic::Mma8451, mode::Standby> {
     /// Create new instance of the MMA8451 device.
     pub fn new_mma8451(i2c: I2C, address: SlaveAddr) -> Self {
         Mma8x5x {
@@ -20,7 +22,7 @@ impl<I2C> Mma8x5x<I2C, ic::Mma8451, mode::Standby> {
     }
 }
 
-impl<I2C> Mma8x5x<I2C, ic::Mma8452, mode::Standby> {
+impl<I2C: I2c> Mma8x5x<I2C, ic::Mma8452, mode::Standby> {
     /// Create new instance of the MMA8452 device.
     pub fn new_mma8452(i2c: I2C, address: SlaveAddr) -> Self {
         Mma8x5x {
@@ -39,7 +41,7 @@ impl<I2C> Mma8x5x<I2C, ic::Mma8452, mode::Standby> {
     }
 }
 
-impl<I2C> Mma8x5x<I2C, ic::Mma8453, mode::Standby> {
+impl<I2C: I2c> Mma8x5x<I2C, ic::Mma8453, mode::Standby> {
     /// Create new instance of the MMA8453 device.
     pub fn new_mma8453(i2c: I2C, address: SlaveAddr) -> Self {
         Mma8x5x {

--- a/src/mma865x.rs
+++ b/src/mma865x.rs
@@ -1,9 +1,11 @@
 //! MLX90614-specific functions
 
+use embedded_hal::i2c::I2c;
+
 use crate::{ic, mode, register_access::BitFlags, Config, Mma8x5x};
 use core::marker::PhantomData;
 
-impl<I2C> Mma8x5x<I2C, ic::Mma8652, mode::Standby> {
+impl<I2C: I2c> Mma8x5x<I2C, ic::Mma8652, mode::Standby> {
     /// Create new instance of the MMA8652 device.
     pub fn new_mma8652(i2c: I2C) -> Self {
         Mma8x5x {
@@ -22,7 +24,7 @@ impl<I2C> Mma8x5x<I2C, ic::Mma8652, mode::Standby> {
     }
 }
 
-impl<I2C> Mma8x5x<I2C, ic::Mma8653, mode::Standby> {
+impl<I2C: I2c> Mma8x5x<I2C, ic::Mma8653, mode::Standby> {
     /// Create new instance of the MMA8653 device.
     pub fn new_mma8653(i2c: I2C) -> Self {
         Mma8x5x {


### PR DESCRIPTION
I fixed the generic i2c arguments in order to fix compilation issues I had in my new project.